### PR TITLE
Update download config schema

### DIFF
--- a/src/matrix_content_scanner/config.py
+++ b/src/matrix_content_scanner/config.py
@@ -92,7 +92,7 @@ _config_schema = {
             "properties": {
                 "base_homeserver_url": {"type": "string"},
                 "proxy": {"type": "string"},
-                "additional_headers" {
+                "additional_headers": {
                     "type": "object",
                     "additionalProperties": {"type": "string"},
                 },


### PR DESCRIPTION
* `download.additional_headers` was missing from the schema despite being present in `DownloadConfig`
* `download.allowed_mimetypes` was present in the schema but absent from `DownloadConfig`