### PR TITLE
Update AGPL headers to include element commercial license

### DIFF
--- a/LICENSE-COMMERCIAL
+++ b/LICENSE-COMMERCIAL
@@ -1,0 +1,6 @@
+Licensees holding a valid commercial license with Element may use this
+software in accordance with the terms contained in a written agreement
+between you and Element.
+
+To purchase a commercial license please contact our sales team at
+licensing@element.io

--- a/src/matrix_content_scanner/__init__.py
+++ b/src/matrix_content_scanner/__init__.py
@@ -1,7 +1,7 @@
 #  Copyright 2022 New Vector Ltd
 #
-# SPDX-License-Identifier: AGPL-3.0-only
-# Please see LICENSE in the repository root for full details.
+# SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+# Please see LICENSE files in the repository root for full details.
 
 from matrix_content_scanner.utils.rust import check_rust_lib_up_to_date
 

--- a/src/matrix_content_scanner/config.py
+++ b/src/matrix_content_scanner/config.py
@@ -1,7 +1,7 @@
 #  Copyright 2022 New Vector Ltd
 #
-# SPDX-License-Identifier: AGPL-3.0-only
-# Please see LICENSE in the repository root for full details.
+# SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+# Please see LICENSE files in the repository root for full details.
 from typing import Any, Dict, List, Optional, Union
 
 import attr

--- a/src/matrix_content_scanner/httpserver.py
+++ b/src/matrix_content_scanner/httpserver.py
@@ -1,7 +1,7 @@
 #  Copyright 2022 New Vector Ltd
 #
-# SPDX-License-Identifier: AGPL-3.0-only
-# Please see LICENSE in the repository root for full details.
+# SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+# Please see LICENSE files in the repository root for full details.
 import logging
 from typing import TYPE_CHECKING, Awaitable, Callable
 

--- a/src/matrix_content_scanner/logutils.py
+++ b/src/matrix_content_scanner/logutils.py
@@ -1,7 +1,7 @@
 #  Copyright 2022 New Vector Ltd
 #
-# SPDX-License-Identifier: AGPL-3.0-only
-# Please see LICENSE in the repository root for full details.
+# SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+# Please see LICENSE files in the repository root for full details.
 import logging
 from contextvars import ContextVar
 from typing import Any

--- a/src/matrix_content_scanner/mcs.py
+++ b/src/matrix_content_scanner/mcs.py
@@ -1,7 +1,7 @@
 # Copyright 2022 New Vector Ltd
 #
-# SPDX-License-Identifier: AGPL-3.0-only
-# Please see LICENSE in the repository root for full details.
+# SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+# Please see LICENSE files in the repository root for full details.
 import argparse
 import logging
 import sys

--- a/src/matrix_content_scanner/scanner/__init__.py
+++ b/src/matrix_content_scanner/scanner/__init__.py
@@ -1,4 +1,4 @@
 #  Copyright 2022 New Vector Ltd
 #
-# SPDX-License-Identifier: AGPL-3.0-only
-# Please see LICENSE in the repository root for full details.
+# SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+# Please see LICENSE files in the repository root for full details.

--- a/src/matrix_content_scanner/scanner/file_downloader.py
+++ b/src/matrix_content_scanner/scanner/file_downloader.py
@@ -1,7 +1,7 @@
 #  Copyright 2022 New Vector Ltd
 #
-# SPDX-License-Identifier: AGPL-3.0-only
-# Please see LICENSE in the repository root for full details.
+# SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+# Please see LICENSE files in the repository root for full details.
 import json
 import logging
 import urllib.parse

--- a/src/matrix_content_scanner/scanner/scanner.py
+++ b/src/matrix_content_scanner/scanner/scanner.py
@@ -1,7 +1,7 @@
 #  Copyright 2022 New Vector Ltd
 #
-# SPDX-License-Identifier: AGPL-3.0-only
-# Please see LICENSE in the repository root for full details.
+# SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+# Please see LICENSE files in the repository root for full details.
 import asyncio
 import hashlib
 import logging

--- a/src/matrix_content_scanner/servlets/__init__.py
+++ b/src/matrix_content_scanner/servlets/__init__.py
@@ -1,7 +1,7 @@
 #  Copyright 2022 New Vector Ltd
 #
-# SPDX-License-Identifier: AGPL-3.0-only
-# Please see LICENSE in the repository root for full details.
+# SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+# Please see LICENSE files in the repository root for full details.
 import functools
 import json
 import logging

--- a/src/matrix_content_scanner/servlets/download.py
+++ b/src/matrix_content_scanner/servlets/download.py
@@ -1,7 +1,7 @@
 #  Copyright 2022 New Vector Ltd
 #
-# SPDX-License-Identifier: AGPL-3.0-only
-# Please see LICENSE in the repository root for full details.
+# SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+# Please see LICENSE files in the repository root for full details.
 from typing import TYPE_CHECKING, Optional, Tuple
 
 from aiohttp import web

--- a/src/matrix_content_scanner/servlets/public_key.py
+++ b/src/matrix_content_scanner/servlets/public_key.py
@@ -1,7 +1,7 @@
 #  Copyright 2022 New Vector Ltd
 #
-# SPDX-License-Identifier: AGPL-3.0-only
-# Please see LICENSE in the repository root for full details.
+# SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+# Please see LICENSE files in the repository root for full details.
 from typing import TYPE_CHECKING, Tuple
 
 from aiohttp import web

--- a/src/matrix_content_scanner/servlets/scan.py
+++ b/src/matrix_content_scanner/servlets/scan.py
@@ -1,7 +1,7 @@
 #  Copyright 2022 New Vector Ltd
 #
-# SPDX-License-Identifier: AGPL-3.0-only
-# Please see LICENSE in the repository root for full details.
+# SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+# Please see LICENSE files in the repository root for full details.
 from typing import TYPE_CHECKING, Optional, Tuple
 
 from aiohttp import web

--- a/src/matrix_content_scanner/servlets/thumbnail.py
+++ b/src/matrix_content_scanner/servlets/thumbnail.py
@@ -1,7 +1,7 @@
 #  Copyright 2022 New Vector Ltd
 #
-# SPDX-License-Identifier: AGPL-3.0-only
-# Please see LICENSE in the repository root for full details.
+# SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+# Please see LICENSE files in the repository root for full details.
 from typing import TYPE_CHECKING, Tuple
 
 from aiohttp import web

--- a/src/matrix_content_scanner/utils/__init__.py
+++ b/src/matrix_content_scanner/utils/__init__.py
@@ -1,4 +1,4 @@
 #  Copyright 2022 New Vector Ltd
 #
-# SPDX-License-Identifier: AGPL-3.0-only
-# Please see LICENSE in the repository root for full details.
+# SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+# Please see LICENSE files in the repository root for full details.

--- a/src/matrix_content_scanner/utils/constants.py
+++ b/src/matrix_content_scanner/utils/constants.py
@@ -1,7 +1,7 @@
 #  Copyright 2022 New Vector Ltd
 #
-# SPDX-License-Identifier: AGPL-3.0-only
-# Please see LICENSE in the repository root for full details.
+# SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+# Please see LICENSE files in the repository root for full details.
 from enum import Enum
 
 

--- a/src/matrix_content_scanner/utils/encrypted_file_metadata.py
+++ b/src/matrix_content_scanner/utils/encrypted_file_metadata.py
@@ -1,7 +1,7 @@
 #  Copyright 2022 New Vector Ltd
 #
-# SPDX-License-Identifier: AGPL-3.0-only
-# Please see LICENSE in the repository root for full details.
+# SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+# Please see LICENSE files in the repository root for full details.
 from jsonschema import ValidationError, validate
 
 from matrix_content_scanner.utils.constants import ErrCode

--- a/src/matrix_content_scanner/utils/errors.py
+++ b/src/matrix_content_scanner/utils/errors.py
@@ -1,7 +1,7 @@
 #  Copyright 2022 New Vector Ltd
 #
-# SPDX-License-Identifier: AGPL-3.0-only
-# Please see LICENSE in the repository root for full details.
+# SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+# Please see LICENSE files in the repository root for full details.
 from typing import Optional
 
 from matrix_content_scanner.utils.constants import ErrCode

--- a/src/matrix_content_scanner/utils/rust.py
+++ b/src/matrix_content_scanner/utils/rust.py
@@ -1,7 +1,7 @@
 #  Copyright 2024 New Vector Ltd
 #
-# SPDX-License-Identifier: AGPL-3.0-only
-# Please see LICENSE in the repository root for full details.
+# SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+# Please see LICENSE files in the repository root for full details.
 
 import os
 import sys

--- a/src/matrix_content_scanner/utils/types.py
+++ b/src/matrix_content_scanner/utils/types.py
@@ -1,7 +1,7 @@
 #  Copyright 2022 New Vector Ltd
 #
-# SPDX-License-Identifier: AGPL-3.0-only
-# Please see LICENSE in the repository root for full details.
+# SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+# Please see LICENSE files in the repository root for full details.
 from typing import Any, Dict
 
 import attr

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,4 @@
 #  Copyright 2022 New Vector Ltd
 #
-# SPDX-License-Identifier: AGPL-3.0-only
-# Please see LICENSE in the repository root for full details.
+# SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+# Please see LICENSE files in the repository root for full details.

--- a/tests/scanner/__init__.py
+++ b/tests/scanner/__init__.py
@@ -1,4 +1,4 @@
 #  Copyright 2022 New Vector Ltd
 #
-# SPDX-License-Identifier: AGPL-3.0-only
-# Please see LICENSE in the repository root for full details.
+# SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+# Please see LICENSE files in the repository root for full details.

--- a/tests/scanner/test_file_downloader.py
+++ b/tests/scanner/test_file_downloader.py
@@ -1,7 +1,7 @@
 #  Copyright 2022 New Vector Ltd
 #
-# SPDX-License-Identifier: AGPL-3.0-only
-# Please see LICENSE in the repository root for full details.
+# SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+# Please see LICENSE files in the repository root for full details.
 import json
 from typing import Dict, List, Optional, Tuple, Union
 from unittest import IsolatedAsyncioTestCase

--- a/tests/scanner/test_scanner.py
+++ b/tests/scanner/test_scanner.py
@@ -1,7 +1,7 @@
 #  Copyright 2022 New Vector Ltd
 #
-# SPDX-License-Identifier: AGPL-3.0-only
-# Please see LICENSE in the repository root for full details.
+# SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+# Please see LICENSE files in the repository root for full details.
 import asyncio
 import copy
 from typing import Any, Dict, List, Optional

--- a/tests/servlets/__init__.py
+++ b/tests/servlets/__init__.py
@@ -1,4 +1,4 @@
 #  Copyright 2022 New Vector Ltd
 #
-# SPDX-License-Identifier: AGPL-3.0-only
-# Please see LICENSE in the repository root for full details.
+# SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+# Please see LICENSE files in the repository root for full details.

--- a/tests/servlets/test_scan.py
+++ b/tests/servlets/test_scan.py
@@ -1,7 +1,7 @@
 #  Copyright 2023 New Vector Ltd
 #
-# SPDX-License-Identifier: AGPL-3.0-only
-# Please see LICENSE in the repository root for full details.
+# SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+# Please see LICENSE files in the repository root for full details.
 from http import HTTPStatus
 from unittest.mock import patch
 

--- a/tests/servlets/test_servlets.py
+++ b/tests/servlets/test_servlets.py
@@ -1,7 +1,7 @@
 #  Copyright 2022 New Vector Ltd
 #
-# SPDX-License-Identifier: AGPL-3.0-only
-# Please see LICENSE in the repository root for full details.
+# SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+# Please see LICENSE files in the repository root for full details.
 import json
 import unittest
 

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -1,7 +1,7 @@
 #  Copyright 2022 New Vector Ltd
 #
-# SPDX-License-Identifier: AGPL-3.0-only
-# Please see LICENSE in the repository root for full details.
+# SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+# Please see LICENSE files in the repository root for full details.
 import json
 import unittest
 

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -1,7 +1,7 @@
 #  Copyright 2022 New Vector Ltd
 #
-# SPDX-License-Identifier: AGPL-3.0-only
-# Please see LICENSE in the repository root for full details.
+# SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+# Please see LICENSE files in the repository root for full details.
 import os
 from binascii import unhexlify
 from typing import Dict, Optional

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -1,4 +1,4 @@
 #  Copyright 2022 New Vector Ltd
 #
-# SPDX-License-Identifier: AGPL-3.0-only
-# Please see LICENSE in the repository root for full details.
+# SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+# Please see LICENSE files in the repository root for full details.

--- a/tests/utils/test_encrypted_file_metadata.py
+++ b/tests/utils/test_encrypted_file_metadata.py
@@ -1,7 +1,7 @@
 #  Copyright 2022 New Vector Ltd
 #
-# SPDX-License-Identifier: AGPL-3.0-only
-# Please see LICENSE in the repository root for full details.
+# SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+# Please see LICENSE files in the repository root for full details.
 import copy
 import unittest
 


### PR DESCRIPTION
This was missed in #66.
Adds information about the Element-Commercial license.