### PR TITLE
Add support for authenticated media

### DIFF
--- a/src/matrix_content_scanner/scanner/file_downloader.py
+++ b/src/matrix_content_scanner/scanner/file_downloader.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 # Please see LICENSE in the repository root for full details.
-import copy
 import json
 import logging
 import urllib.parse
@@ -349,14 +348,12 @@ class FileDownloader:
         try:
             logger.info("Sending GET request to %s", url)
             async with aiohttp.ClientSession() as session:
-                # TODO: Test we don't persist auth token
-                request_headers = copy.deepcopy(self._headers)
-                if auth_header is not None:
-                    auth_dict = {"Authorization": auth_header}
-                    if request_headers is None:
-                        request_headers = auth_dict
-                    else:
-                        request_headers.update(auth_dict)
+                if auth_header is None:
+                    request_headers = self._headers
+                else:
+                    request_headers = {"Authorization": auth_header}
+                    if self._headers is not None:
+                        request_headers = {**request_headers, **self._headers}
 
                 async with session.get(
                     url,

--- a/src/matrix_content_scanner/scanner/file_downloader.py
+++ b/src/matrix_content_scanner/scanner/file_downloader.py
@@ -33,6 +33,8 @@ class _PathNotFoundException(Exception):
 class FileDownloader:
     MEDIA_DOWNLOAD_PREFIX = "_matrix/media/%s/download"
     MEDIA_THUMBNAIL_PREFIX = "_matrix/media/%s/thumbnail"
+    MEDIA_DOWNLOAD_AUTHENTICATED_PREFIX = "_matrix/client/v1/media/download"
+    MEDIA_THUMBNAIL_AUTHENTICATED_PREFIX = "_matrix/client/v1/media/thumbnail"
 
     def __init__(self, mcs: "MatrixContentScanner"):
         self._base_url = mcs.config.download.base_homeserver_url
@@ -44,6 +46,7 @@ class FileDownloader:
         self,
         media_path: str,
         thumbnail_params: Optional[MultiMapping[str]] = None,
+        auth_header: Optional[str] = None,
     ) -> MediaDescription:
         """Retrieve the file with the given `server_name/media_id` path, and stores it on
         disk.
@@ -52,6 +55,8 @@ class FileDownloader:
             media_path: The path identifying the media to retrieve.
             thumbnail_params: If present, then we want to request and scan a thumbnail
                 generated with the provided parameters instead of the full media.
+            auth_header: If present, we forward the given Authorization header, this is
+                required for authenticated media endpoints.
 
         Returns:
             A description of the file (including its full content).
@@ -60,27 +65,26 @@ class FileDownloader:
             ContentScannerRestError: The file was not found or could not be downloaded due
                 to an error on the remote homeserver's side.
         """
-        url = await self._build_https_url(
-            media_path, for_thumbnail=thumbnail_params is not None
-        )
+
+        prefix = self.MEDIA_DOWNLOAD_AUTHENTICATED_PREFIX if auth_header is not None else self.MEDIA_DOWNLOAD_PREFIX
+        if thumbnail_params is not None:
+            prefix = self.MEDIA_THUMBNAIL_AUTHENTICATED_PREFIX if auth_header is not None else self.MEDIA_THUMBNAIL_PREFIX
+
+        url = await self._build_https_url(media_path, prefix)
 
         # Attempt to retrieve the file at the generated URL.
         try:
-            file = await self._get_file_content(url, thumbnail_params)
+            file = await self._get_file_content(url, thumbnail_params, auth_header)
         except _PathNotFoundException:
             # If the file could not be found, it might be because the homeserver hasn't
             # been upgraded to a version that supports Matrix v1.1 endpoints yet, so try
             # again with an r0 endpoint.
             logger.info("File not found, trying legacy r0 path")
 
-            url = await self._build_https_url(
-                media_path,
-                endpoint_version="r0",
-                for_thumbnail=thumbnail_params is not None,
-            )
+            url = await self._build_https_url(media_path, prefix, endpoint_version="r0")
 
             try:
-                file = await self._get_file_content(url, thumbnail_params)
+                file = await self._get_file_content(url, thumbnail_params, auth_header)
             except _PathNotFoundException:
                 # If that still failed, raise an error.
                 raise ContentScannerRestError(
@@ -94,9 +98,8 @@ class FileDownloader:
     async def _build_https_url(
         self,
         media_path: str,
+        prefix: str,
         endpoint_version: str = "v3",
-        *,
-        for_thumbnail: bool,
     ) -> str:
         """Turn a `server_name/media_id` path into an https:// one we can use to fetch
         the media.
@@ -108,9 +111,6 @@ class FileDownloader:
             media_path: The media path to translate.
             endpoint_version: The version of the download endpoint to use. As of Matrix
                 v1.1, this is either "v3" or "r0".
-            for_thumbnail: True if a server-side thumbnail is desired instead of the full
-                media. In that case, the URL for the `/thumbnail` endpoint is returned
-                instead of the `/download` endpoint.
 
         Returns:
             An https URL to use. If `base_homeserver_url` is set in the config, this
@@ -140,9 +140,6 @@ class FileDownloader:
                 # didn't find a .well-known file.
                 base_url = "https://" + server_name
 
-        prefix = (
-            self.MEDIA_THUMBNAIL_PREFIX if for_thumbnail else self.MEDIA_DOWNLOAD_PREFIX
-        )
 
         # Build the full URL.
         path_prefix = prefix % endpoint_version
@@ -159,12 +156,15 @@ class FileDownloader:
         self,
         url: str,
         thumbnail_params: Optional[MultiMapping[str]],
+        auth_header: Optional[str] = None,
     ) -> MediaDescription:
         """Retrieve the content of the file at a given URL.
 
         Args:
             url: The URL to query.
             thumbnail_params: Query parameters used if the request is for a thumbnail.
+            auth_header: If present, we forward the given Authorization header, this is
+                required for authenticated media endpoints.
 
         Returns:
             A description of the file (including its full content).
@@ -178,7 +178,7 @@ class FileDownloader:
             ContentScannerRestError: the server returned a non-200 status which cannot
                 meant that the path wasn't understood.
         """
-        code, body, headers = await self._get(url, query=thumbnail_params)
+        code, body, headers = await self._get(url, query=thumbnail_params, auth_header=auth_header)
 
         logger.info("Remote server responded with %d", code)
 
@@ -307,12 +307,15 @@ class FileDownloader:
         self,
         url: str,
         query: Optional[MultiMapping[str]] = None,
+        auth_header: Optional[str] = None,
     ) -> Tuple[int, bytes, CIMultiDictProxy[str]]:
         """Sends a GET request to the provided URL.
 
         Args:
             url: The URL to send requests to.
             query: Optional parameters to use in the request's query string.
+            auth_header: If present, we forward the given Authorization header, this is
+                required for authenticated media endpoints.
 
         Returns:
             The HTTP status code, body and headers the remote server responded with.
@@ -324,6 +327,8 @@ class FileDownloader:
         try:
             logger.info("Sending GET request to %s", url)
             async with aiohttp.ClientSession() as session:
+                if auth_header is not None:
+                    self._headers.update("Authorization", auth_header)
                 async with session.get(
                     url,
                     proxy=self._proxy_url,

--- a/src/matrix_content_scanner/scanner/file_downloader.py
+++ b/src/matrix_content_scanner/scanner/file_downloader.py
@@ -198,7 +198,9 @@ class FileDownloader:
             ContentScannerRestError: the server returned a non-200 status which cannot
                 meant that the path wasn't understood.
         """
-        code, body, headers = await self._get(url, query=thumbnail_params, auth_header=auth_header)
+        code, body, headers = await self._get(
+            url, query=thumbnail_params, auth_header=auth_header
+        )
 
         logger.info("Remote server responded with %d", code)
 

--- a/src/matrix_content_scanner/scanner/file_downloader.py
+++ b/src/matrix_content_scanner/scanner/file_downloader.py
@@ -40,7 +40,11 @@ class FileDownloader:
         self._base_url = mcs.config.download.base_homeserver_url
         self._well_known_cache: Dict[str, Optional[str]] = {}
         self._proxy_url = mcs.config.download.proxy
-        self._headers = mcs.config.download.additional_headers
+        self._headers = (
+            mcs.config.download.additional_headers
+            if mcs.config.download.additional_headers is not None
+            else {}
+        )
 
     async def download_file(
         self,
@@ -348,12 +352,10 @@ class FileDownloader:
         try:
             logger.info("Sending GET request to %s", url)
             async with aiohttp.ClientSession() as session:
-                if auth_header is None:
-                    request_headers = self._headers
+                if auth_header is not None:
+                    request_headers = {"Authorization": auth_header, **self._headers}
                 else:
-                    request_headers = {"Authorization": auth_header}
-                    if self._headers is not None:
-                        request_headers = {**request_headers, **self._headers}
+                    request_headers = self._headers
 
                 async with session.get(
                     url,

--- a/src/matrix_content_scanner/scanner/scanner.py
+++ b/src/matrix_content_scanner/scanner/scanner.py
@@ -100,6 +100,7 @@ class Scanner:
         media_path: str,
         metadata: Optional[JsonDict] = None,
         thumbnail_params: Optional["MultiMapping[str]"] = None,
+        auth_header: Optional[str] = None
     ) -> MediaDescription:
         """Download and scan the given media.
 
@@ -119,6 +120,8 @@ class Scanner:
                 the file isn't encrypted.
             thumbnail_params: If present, then we want to request and scan a thumbnail
                 generated with the provided parameters instead of the full media.
+            auth_header: If present, we forward the given Authorization header, this is
+                required for authenticated media endpoints.
 
         Returns:
             A description of the media.
@@ -141,7 +144,7 @@ class Scanner:
             # Try to download and scan the file.
             try:
                 res = await self._scan_file(
-                    cache_key, media_path, metadata, thumbnail_params
+                    cache_key, media_path, metadata, thumbnail_params, auth_header
                 )
                 # Set the future's result, and mark it as done.
                 f.set_result(res)
@@ -168,6 +171,7 @@ class Scanner:
         media_path: str,
         metadata: Optional[JsonDict] = None,
         thumbnail_params: Optional[MultiMapping[str]] = None,
+        auth_header: Optional[str] = None,
     ) -> MediaDescription:
         """Download and scan the given media.
 
@@ -185,6 +189,8 @@ class Scanner:
                 the file isn't encrypted.
             thumbnail_params: If present, then we want to request and scan a thumbnail
                 generated with the provided parameters instead of the full media.
+            auth_header: If present, we forward the given Authorization header, this is
+                required for authenticated media endpoints.
 
         Returns:
             A description of the media.
@@ -218,6 +224,7 @@ class Scanner:
             media = await self._file_downloader.download_file(
                 media_path=media_path,
                 thumbnail_params=thumbnail_params,
+                auth_header=auth_header,
             )
 
             # Compare the media's hash to ensure the server hasn't changed the file since
@@ -251,6 +258,7 @@ class Scanner:
             media = await self._file_downloader.download_file(
                 media_path=media_path,
                 thumbnail_params=thumbnail_params,
+                auth_header=auth_header,
             )
 
         # Download and scan the file.

--- a/src/matrix_content_scanner/scanner/scanner.py
+++ b/src/matrix_content_scanner/scanner/scanner.py
@@ -100,7 +100,7 @@ class Scanner:
         media_path: str,
         metadata: Optional[JsonDict] = None,
         thumbnail_params: Optional["MultiMapping[str]"] = None,
-        auth_header: Optional[str] = None
+        auth_header: Optional[str] = None,
     ) -> MediaDescription:
         """Download and scan the given media.
 

--- a/src/matrix_content_scanner/servlets/download.py
+++ b/src/matrix_content_scanner/servlets/download.py
@@ -28,7 +28,9 @@ class DownloadHandler:
         metadata: Optional[JsonDict] = None,
         auth_header: Optional[str] = None,
     ) -> Tuple[int, _BytesResponse]:
-        media = await self._scanner.scan_file(media_path, metadata, auth_header=auth_header)
+        media = await self._scanner.scan_file(
+            media_path, metadata, auth_header=auth_header
+        )
 
         return 200, _BytesResponse(
             headers=media.response_headers,
@@ -39,7 +41,9 @@ class DownloadHandler:
     async def handle_plain(self, request: web.Request) -> Tuple[int, _BytesResponse]:
         """Handles GET requests to ../download/serverName/mediaId"""
         media_path = request.match_info["media_path"]
-        return await self._scan(media_path, auth_header=request.headers.get("Authorization"))
+        return await self._scan(
+            media_path, auth_header=request.headers.get("Authorization")
+        )
 
     @web_handler
     async def handle_encrypted(
@@ -50,4 +54,6 @@ class DownloadHandler:
             request, self._crypto_handler
         )
 
-        return await self._scan(media_path, metadata, auth_header=request.headers.get("Authorization"))
+        return await self._scan(
+            media_path, metadata, auth_header=request.headers.get("Authorization")
+        )

--- a/src/matrix_content_scanner/servlets/download.py
+++ b/src/matrix_content_scanner/servlets/download.py
@@ -26,8 +26,9 @@ class DownloadHandler:
         self,
         media_path: str,
         metadata: Optional[JsonDict] = None,
+        auth_header: Optional[str] = None,
     ) -> Tuple[int, _BytesResponse]:
-        media = await self._scanner.scan_file(media_path, metadata)
+        media = await self._scanner.scan_file(media_path, metadata, auth_header=auth_header)
 
         return 200, _BytesResponse(
             headers=media.response_headers,
@@ -38,7 +39,7 @@ class DownloadHandler:
     async def handle_plain(self, request: web.Request) -> Tuple[int, _BytesResponse]:
         """Handles GET requests to ../download/serverName/mediaId"""
         media_path = request.match_info["media_path"]
-        return await self._scan(media_path)
+        return await self._scan(media_path, auth_header=request.headers.get("Authorization"))
 
     @web_handler
     async def handle_encrypted(
@@ -49,4 +50,4 @@ class DownloadHandler:
             request, self._crypto_handler
         )
 
-        return await self._scan(media_path, metadata)
+        return await self._scan(media_path, metadata, auth_header=request.headers.get("Authorization"))

--- a/src/matrix_content_scanner/servlets/scan.py
+++ b/src/matrix_content_scanner/servlets/scan.py
@@ -38,7 +38,9 @@ class ScanHandler:
     async def handle_plain(self, request: web.Request) -> Tuple[int, JsonDict]:
         """Handles GET requests to ../scan/serverName/mediaId"""
         media_path = request.match_info["media_path"]
-        return await self._scan_and_format(media_path, auth_header=request.headers.get("Authorization"))
+        return await self._scan_and_format(
+            media_path, auth_header=request.headers.get("Authorization")
+        )
 
     @web_handler
     async def handle_encrypted(self, request: web.Request) -> Tuple[int, JsonDict]:
@@ -46,4 +48,6 @@ class ScanHandler:
         media_path, metadata = await get_media_metadata_from_request(
             request, self._crypto_handler
         )
-        return await self._scan_and_format(media_path, metadata, auth_header=request.headers.get("Authorization"))
+        return await self._scan_and_format(
+            media_path, metadata, auth_header=request.headers.get("Authorization")
+        )

--- a/src/matrix_content_scanner/servlets/scan.py
+++ b/src/matrix_content_scanner/servlets/scan.py
@@ -23,9 +23,10 @@ class ScanHandler:
         self,
         media_path: str,
         metadata: Optional[JsonDict] = None,
+        auth_header: Optional[str] = None,
     ) -> Tuple[int, JsonDict]:
         try:
-            await self._scanner.scan_file(media_path, metadata)
+            await self._scanner.scan_file(media_path, metadata, auth_header=auth_header)
         except FileDirtyError as e:
             res = {"clean": False, "info": e.info}
         else:
@@ -37,7 +38,7 @@ class ScanHandler:
     async def handle_plain(self, request: web.Request) -> Tuple[int, JsonDict]:
         """Handles GET requests to ../scan/serverName/mediaId"""
         media_path = request.match_info["media_path"]
-        return await self._scan_and_format(media_path)
+        return await self._scan_and_format(media_path, auth_header=request.headers.get("Authorization"))
 
     @web_handler
     async def handle_encrypted(self, request: web.Request) -> Tuple[int, JsonDict]:
@@ -45,4 +46,4 @@ class ScanHandler:
         media_path, metadata = await get_media_metadata_from_request(
             request, self._crypto_handler
         )
-        return await self._scan_and_format(media_path, metadata)
+        return await self._scan_and_format(media_path, metadata, auth_header=request.headers.get("Authorization"))

--- a/src/matrix_content_scanner/servlets/thumbnail.py
+++ b/src/matrix_content_scanner/servlets/thumbnail.py
@@ -26,6 +26,7 @@ class ThumbnailHandler:
         media = await self._scanner.scan_file(
             media_path=media_path,
             thumbnail_params=request.query,
+            auth_header=request.headers.get("Authorization")
         )
 
         return 200, _BytesResponse(

--- a/src/matrix_content_scanner/servlets/thumbnail.py
+++ b/src/matrix_content_scanner/servlets/thumbnail.py
@@ -26,7 +26,7 @@ class ThumbnailHandler:
         media = await self._scanner.scan_file(
             media_path=media_path,
             thumbnail_params=request.query,
-            auth_header=request.headers.get("Authorization")
+            auth_header=request.headers.get("Authorization"),
         )
 
         return 200, _BytesResponse(

--- a/tests/scanner/test_file_downloader.py
+++ b/tests/scanner/test_file_downloader.py
@@ -37,7 +37,7 @@ class FileDownloaderTestCase(IsolatedAsyncioTestCase):
         self.media_headers = get_base_media_headers()
 
         async def _get(
-            url: str, query: Optional[MultiDictProxy[str]] = None
+            url: str, query: Optional[MultiDictProxy[str]] = None, auth_header: Optional[str] = None,
         ) -> Tuple[int, bytes, CIMultiDictProxy[str]]:
             """Mock for the _get method on the file downloader that doesn't serve a
             .well-known client file.
@@ -88,7 +88,7 @@ class FileDownloaderTestCase(IsolatedAsyncioTestCase):
         )
         self.assertEqual(
             self.get_mock.mock_calls[1],
-            call("https://foo/_matrix/media/v3/download/" + MEDIA_PATH, query=None),
+            call("https://foo/_matrix/media/v3/download/" + MEDIA_PATH, query=None, auth_header=None),
         )
 
     async def test_retry_on_404(self) -> None:
@@ -128,13 +128,13 @@ class FileDownloaderTestCase(IsolatedAsyncioTestCase):
         self.assertEqual(
             self.get_mock.mock_calls[0],
             call(
-                "http://my-site.com/_matrix/media/v3/download/" + MEDIA_PATH, query=None
+                "http://my-site.com/_matrix/media/v3/download/" + MEDIA_PATH, query=None, auth_header=None,
             ),
         )
         self.assertEqual(
             self.get_mock.mock_calls[1],
             call(
-                "http://my-site.com/_matrix/media/r0/download/" + MEDIA_PATH, query=None
+                "http://my-site.com/_matrix/media/r0/download/" + MEDIA_PATH, query=None, auth_header=None,
             ),
         )
 
@@ -203,7 +203,7 @@ class WellKnownDiscoveryTestCase(IsolatedAsyncioTestCase):
         self.versions_status = 200
 
         async def _get(
-            url: str, query: Optional[MultiDictProxy[str]] = None
+            url: str, query: Optional[MultiDictProxy[str]] = None, auth_header: Optional[str] = None,
         ) -> Tuple[int, bytes, CIMultiDictProxy[str]]:
             """Mock for the _get method on the file downloader that serves a .well-known
             client file.

--- a/tests/scanner/test_file_downloader.py
+++ b/tests/scanner/test_file_downloader.py
@@ -37,7 +37,9 @@ class FileDownloaderTestCase(IsolatedAsyncioTestCase):
         self.media_headers = get_base_media_headers()
 
         async def _get(
-            url: str, query: Optional[MultiDictProxy[str]] = None, auth_header: Optional[str] = None,
+            url: str,
+            query: Optional[MultiDictProxy[str]] = None,
+            auth_header: Optional[str] = None,
         ) -> Tuple[int, bytes, CIMultiDictProxy[str]]:
             """Mock for the _get method on the file downloader that doesn't serve a
             .well-known client file.
@@ -88,7 +90,11 @@ class FileDownloaderTestCase(IsolatedAsyncioTestCase):
         )
         self.assertEqual(
             self.get_mock.mock_calls[1],
-            call("https://foo/_matrix/media/v3/download/" + MEDIA_PATH, query=None, auth_header=None),
+            call(
+                "https://foo/_matrix/media/v3/download/" + MEDIA_PATH,
+                query=None,
+                auth_header=None,
+            ),
         )
 
     async def test_retry_on_404(self) -> None:
@@ -128,13 +134,17 @@ class FileDownloaderTestCase(IsolatedAsyncioTestCase):
         self.assertEqual(
             self.get_mock.mock_calls[0],
             call(
-                "http://my-site.com/_matrix/media/v3/download/" + MEDIA_PATH, query=None, auth_header=None,
+                "http://my-site.com/_matrix/media/v3/download/" + MEDIA_PATH,
+                query=None,
+                auth_header=None,
             ),
         )
         self.assertEqual(
             self.get_mock.mock_calls[1],
             call(
-                "http://my-site.com/_matrix/media/r0/download/" + MEDIA_PATH, query=None, auth_header=None,
+                "http://my-site.com/_matrix/media/r0/download/" + MEDIA_PATH,
+                query=None,
+                auth_header=None,
             ),
         )
 
@@ -203,7 +213,9 @@ class WellKnownDiscoveryTestCase(IsolatedAsyncioTestCase):
         self.versions_status = 200
 
         async def _get(
-            url: str, query: Optional[MultiDictProxy[str]] = None, auth_header: Optional[str] = None,
+            url: str,
+            query: Optional[MultiDictProxy[str]] = None,
+            auth_header: Optional[str] = None,
         ) -> Tuple[int, bytes, CIMultiDictProxy[str]]:
             """Mock for the _get method on the file downloader that serves a .well-known
             client file.

--- a/tests/scanner/test_scanner.py
+++ b/tests/scanner/test_scanner.py
@@ -42,6 +42,7 @@ class ScannerTestCase(IsolatedAsyncioTestCase):
         async def download_file(
             media_path: str,
             thumbnail_params: Optional[Dict[str, List[str]]] = None,
+            auth_header: Optional[str] = None,
         ) -> MediaDescription:
             """Mock for the file downloader's `download_file` method."""
             return self.downloader_res


### PR DESCRIPTION
This PR adds support for authenticated media by passing the Authorization header information through from the client to the homeserver.
Once MAS supports scoped access tokens this code should be changed over to use that. 

Huge shoutout to @S7evinK  for doing the bulk of the implementation on this.