### PR TITLE
Return auth specific errors when downloading media

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -27,6 +27,9 @@ status code of the response for each scenario:
 |-------------|-------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | 400         | `MCS_MALFORMED_JSON`          | The request body contains malformed JSON.                                                                                                                                         |
 | 400         | `MCS_MEDIA_FAILED_TO_DECRYPT` | The server failed to decrypt the encrypted media downloaded from the media repo.                                                                                                  |
+| 401         | `M_MISSING_TOKEN`             | The request is missing a required access token for authentication.                                                                                                                |
+| 401         | `M_UNKNOWN_TOKEN`             | The access token provided for authentication is not valid.                                                                                                                        |
+| 404         | `M_NOT_FOUND`                 | The `Authorization` header was missing when requesting authenticated media.                                                                                                       |
 | 404         | `M_NOT_FOUND`                 | No route could be found at the given path.                                                                                                                                        |
 | 404         | `M_NOT_FOUND`                 | The requested media was not present in the media repo.                                                                                                                            |
 | 403         | `MCS_MEDIA_NOT_CLEAN`         | The server scanned the downloaded media but the antivirus script returned a non-zero exit code.                                                                                   |
@@ -199,8 +202,3 @@ Example authorization header:
 ```
 Authorization: Bearer <access_token>
 ```
-
-If a request is made for authenticated media and the access token is invalid, the content scanner
-will respond with HTTP status 502, errcode `MCS_MEDIA_REQUEST_FAILED`.
-If a request is made for authenticated media and the `Authorization` header is missing, the content
-scanner will respond with HTTP status 404, errcode `M_NOT_FOUND`.

--- a/src/matrix_content_scanner/scanner/file_downloader.py
+++ b/src/matrix_content_scanner/scanner/file_downloader.py
@@ -221,6 +221,24 @@ class FileDownloader:
                 except (json.decoder.JSONDecodeError, KeyError):
                     pass
 
+            if code == 401:
+                try:
+                    err = json.loads(body)
+                    if err["errcode"] == ErrCode.MISSING_TOKEN:
+                        raise ContentScannerRestError(
+                            HTTPStatus.UNAUTHORIZED,
+                            ErrCode.MISSING_TOKEN,
+                            "Access token missing from request",
+                        )
+                    if err["errcode"] == ErrCode.UNKNOWN_TOKEN:
+                        raise ContentScannerRestError(
+                            HTTPStatus.UNAUTHORIZED,
+                            ErrCode.UNKNOWN_TOKEN,
+                            "Invalid access token passed",
+                        )
+                except (json.decoder.JSONDecodeError, KeyError):
+                    pass
+
             if code == 404:
                 raise _PathNotFoundException
 

--- a/src/matrix_content_scanner/utils/constants.py
+++ b/src/matrix_content_scanner/utils/constants.py
@@ -12,6 +12,15 @@ class ErrCode(str, Enum):
     # - No route was found with the path and method provided in the request.
     # - The homeserver does not have the requested piece of media.
     NOT_FOUND = "M_NOT_FOUND"
+    # The access token is missing from the request.
+    MISSING_TOKEN = "M_MISSING_TOKEN"
+    # The provided access token is invalid.
+    # One of the following:
+    # - the access token was never valid.
+    # - the access token has been logged out.
+    # - the access token has been soft logged out.
+    # - [Added in v1.3] the access token needs to be refreshed.
+    UNKNOWN_TOKEN = "M_UNKNOWN_TOKEN"
     # The file failed the scan.
     NOT_CLEAN = "MCS_MEDIA_NOT_CLEAN"
     # The file could not be retrieved from the homeserver.


### PR DESCRIPTION
Fixes #72 

Also updates the auth media error code docs to move the auth media specific errors up into the `Error codes` section with the rest of the possible content scanner errors.