### PR TITLE
Add scan file body endpoint

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -128,6 +128,26 @@ Downloads a specified encrypted file, decrypts it and then behaves identically t
 The request body for this route is the same as for
 `POST /_matrix/media_proxy/unstable/download_encrypted`.
 
+### `POST /_matrix/media_proxy/unstable/scan_file`
+
+Performs a scan on a file body without uploading to Matrix. This request takes a multi-part / form data
+body.
+
+Response format:
+
+| Parameter | Type | Description                                                        |
+|-----------|------|--------------------------------------------------------------------|
+| `body`    | [Blob](https://developer.mozilla.org/en-US/docs/Web/API/Blob) | The file body. |
+| `file`    | EncryptedFile as JSON string  | The metadata (decryption key) of an encrypted file. Follows the format of the `EncryptedFile` structure from the [Matrix specification](https://spec.matrix.org/v1.2/client-server-api/#extensions-to-mroommessage-msgtypes). Only required if the file is encrypted. |
+
+Example:
+
+```json
+{
+    "clean": false,
+    "info": "***VIRUS DETECTED***"
+}
+```
 
 ### `GET /_matrix/media_proxy/unstable/public_key`
 

--- a/src/matrix_content_scanner/httpserver.py
+++ b/src/matrix_content_scanner/httpserver.py
@@ -109,6 +109,7 @@ class HTTPServer:
             [
                 web.get("/scan" + _MEDIA_PATH_REGEXP, scan_handler.handle_plain),
                 web.post("/scan_encrypted", scan_handler.handle_encrypted),
+                web.post("/scan_file", scan_handler.handle_file),
                 web.get(
                     "/download" + _MEDIA_PATH_REGEXP, download_handler.handle_plain
                 ),

--- a/src/matrix_content_scanner/servlets/__init__.py
+++ b/src/matrix_content_scanner/servlets/__init__.py
@@ -180,6 +180,31 @@ async def get_media_metadata_from_request(
     return media_path, metadata
 
 
+async def get_media_metadata_from_filebody(
+    file_body: JsonDict,
+    crypto_handler: crypto.CryptoHandler,
+) -> JsonDict:
+    """Extracts, optionally decrypts, and validates encrypted file metadata from a
+    request body.
+
+    Args:
+        request: The request to extract the data from.
+        crypto_handler: The crypto handler to use if we need to decrypt an Olm-encrypted
+            body.
+
+    Raises:
+        ContentScannerRestError(400) if the request's body is None or if the metadata
+            didn't pass schema validation.
+    """
+    metadata = _metadata_from_body(file_body, crypto_handler)
+
+    validate_encrypted_file_metadata(metadata)
+
+    # URL parameter is ignored.
+
+    return metadata
+
+
 def _metadata_from_body(
     body: JsonDict, crypto_handler: crypto.CryptoHandler
 ) -> JsonDict:

--- a/src/matrix_content_scanner/servlets/scan.py
+++ b/src/matrix_content_scanner/servlets/scan.py
@@ -2,12 +2,18 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
 # Please see LICENSE files in the repository root for full details.
+import json
 from typing import TYPE_CHECKING, Optional, Tuple
 
-from aiohttp import web
+from aiohttp import BodyPartReader, web
 
-from matrix_content_scanner.servlets import get_media_metadata_from_request, web_handler
-from matrix_content_scanner.utils.errors import FileDirtyError
+from matrix_content_scanner.servlets import (
+    get_media_metadata_from_filebody,
+    get_media_metadata_from_request,
+    web_handler,
+)
+from matrix_content_scanner.utils.constants import ErrCode
+from matrix_content_scanner.utils.errors import ContentScannerRestError, FileDirtyError
 from matrix_content_scanner.utils.types import JsonDict
 
 if TYPE_CHECKING:
@@ -51,3 +57,55 @@ class ScanHandler:
         return await self._scan_and_format(
             media_path, metadata, auth_header=request.headers.get("Authorization")
         )
+
+    @web_handler
+    async def handle_file(self, request: web.Request) -> Tuple[int, JsonDict]:
+        """Handles GET requests to ../scan_file"""
+        try:
+            reader = await request.multipart()
+        except Exception:
+            raise ContentScannerRestError(
+                400,
+                ErrCode.MALFORMED_MULTIPART,
+                "Request body was not a multipart body.",
+            )
+
+        body = None
+        metadata: Optional[JsonDict] = None
+
+        # Iterate to find the fields.
+        while True:
+            field = await reader.next()
+            if (metadata and body) or field is None:
+                break
+            if not isinstance(field, BodyPartReader):
+                continue
+            if field.name == "file":
+                try:
+                    file_json = await field.json()
+                    if file_json is None:
+                        raise Exception("'file' field is empty")
+                except json.decoder.JSONDecodeError as e:
+                    raise ContentScannerRestError(400, ErrCode.MALFORMED_JSON, str(e))
+
+                metadata = await get_media_metadata_from_filebody(
+                    file_json, self._crypto_handler
+                )
+            elif field.name == "body":
+                body = await self._scanner.write_multipart_to_disk(field)
+
+        if body is None:
+            raise ContentScannerRestError(
+                400, ErrCode.MALFORMED_MULTIPART, "Missing 'body' field"
+            )
+
+        # 'metadata' is optional
+
+        try:
+            await self._scanner.scan_file_on_disk(body, metadata)
+        except FileDirtyError as e:
+            res = {"clean": False, "info": e.info}
+        else:
+            res = {"clean": True, "info": "File is clean"}
+
+        return 200, res

--- a/src/matrix_content_scanner/utils/constants.py
+++ b/src/matrix_content_scanner/utils/constants.py
@@ -32,3 +32,5 @@ class ErrCode(str, Enum):
     MALFORMED_JSON = "MCS_MALFORMED_JSON"
     # The Mime type is not in the allowed list of Mime types.
     MIME_TYPE_FORBIDDEN = "MCS_MIME_TYPE_FORBIDDEN"
+    # The body was not a multipart.
+    MALFORMED_MULTIPART = "MCS_MALFORMED_MULTIPART"


### PR DESCRIPTION
Fixes #78 

This adds a new endpoint `POST /_matrix/media_proxy/unstable/scan_file` which takes a multipart body of a file and JSON object for decrypting. 