### PR TITLE
Add linux/arm64 to the docker build platforms.

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -37,6 +37,9 @@ jobs:
             type=raw,value=latest
             type=pep440,pattern={{raw}}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+
       - name: Build and push all platforms
         id: build-and-push
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
@@ -45,7 +48,7 @@ jobs:
           labels: "gitsha1=${{ github.sha }}"
           tags: "${{ steps.set-tag.outputs.tags }}"
           file: "docker/Dockerfile"
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
 
       - name: Sign the images with GitHub OIDC Token
         env:


### PR DESCRIPTION
There isn't an OCI container image published for ARM64, so this PR adds the platform to the docker workflow to make testing easier on macOS.

I've tested that it builds for `arm64` with

```sh
container build --platform linux/arm64 --file docker/Dockerfile --tag matrix-content-scanner:arm64 .
container image inspect matrix-content-scanner:arm64
```

which was successful and indicates the correct platform

```json
"platform" : {
  "architecture" : "arm64",
  "os" : "linux"
},
```

I can spin up a container from the image which starts and is reachable (but I haven't tried to scan any media).

Full disclosure: The changes were made with the suggestions from an LLM and they look correct to me from my research, but my personal experience in this area is basically limited to running `container build xyz` locally.