### PR TITLE
Add comment around the config sample

### DIFF
--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -119,12 +119,9 @@ crypto:
     # Path to the file containing the request secret.
     # The secret is used to derive the key pair for encrypting and decrypting
     # POST request bodies. The secret itself must be an x25519 private key,
-    # consisting of 32 bytes, then base64-encoded.
+    # consisting of 32 random bytes, then base64-encoded.
     # The secret can be generated with:
     #
-    # openssl genpkey -algorithm X25519 -outform DER \
-    # | openssl asn1parse -inform DER -strparse 14 -out /dev/stdout -noout \
-    # | openssl enc -base64 -A > ./path/to/request_secret
-    #
+    # openssl rand -base64 32 > ./path/to/request_secret
     # Required.
     request_secret_path: "./request_secret"

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -118,7 +118,13 @@ download:
 crypto:
     # Path to the file containing the request secret.
     # The secret is used to derive the key pair for encrypting and decrypting
-    # POST request bodies. The secret itself must be exactly 32 bytes, then 
-    # base64-encoded.
+    # POST request bodies. The secret itself must be an x25519 private key,
+    # consisting of 32 bytes, then base64-encoded.
+    # The secret can be generated with:
+    #
+    # openssl genpkey -algorithm X25519 -outform DER \
+    # | openssl asn1parse -inform DER -strparse 14 -out /dev/stdout -noout \
+    # | openssl enc -base64 -A > ./path/to/request_secret
+    #
     # Required.
     request_secret_path: "./request_secret"


### PR DESCRIPTION
I think this information needs to be near the secret configuration. At the moment it is only present in the release note : https://github.com/element-hq/matrix-content-scanner-python/releases/tag/v1.3.0

People could risk generating any random 32 bytes, thinking it would be a valid private key. But x25519 has a couple more constraints, so any random 32 bytes would not be correct.