### PR TITLE
Update release instructions since `setup.cfg` doesn't existing anymore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,7 +5,6 @@
 !src
 !README.md
 !pyproject.toml
-!setup.cfg
 !poetry.lock
 !Cargo.toml
 !Cargo.lock

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Synapse developers (assuming a Unix-like shell):
     version=X.Y.Z
     ```
 
- 2. Update `setup.cfg` so that the `version` is correct.
+ 2. Update `pyproject.toml` so that the `version` is correct.
 
  3. Stage the changed files and commit.
     ```shell


### PR DESCRIPTION
Update release instructions since `setup.cfg` doesn't existing anymore

`setup.cfg` was removed in https://github.com/element-hq/matrix-content-scanner-python/pull/67