### PR TITLE
Fix arm64 docker builds

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -40,6 +40,11 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+        with:
+          driver: docker-container
+
       - name: Build and push all platforms
         id: build-and-push
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -33,9 +33,17 @@ jobs:
         uses: docker/metadata-action@703896b4f30f62d53f5530a80bcdc589a3f702bc # master
         with:
           images: vectorim/matrix-content-scanner
+          # Don't automatically set the `latest` tag.
+          flavor: |
+            latest=false
+          # Only update the `latest` image tag if we're pushing a git tag.
+          # Otherwise, always push a `sha-xxx` tag.
+          # If no tags are selected, and `push: true` is set below, then this
+          # workflow would fail.
           tags: |
-            type=raw,value=latest
+            type=raw,value=latest,enable=${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
             type=pep440,pattern={{raw}}
+            type=sha,prefix=sha-,format=short
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0

--- a/README.md
+++ b/README.md
@@ -130,3 +130,8 @@ Synapse developers (assuming a Unix-like shell):
     python -m build
     twine upload dist/matrix_content_scanner-$version*
     ```
+
+ 9. Double-check that [the docker image build has
+    succeeded](https://github.com/element-hq/matrix-content-scanner-python/actions/workflows/docker.yaml?query=event%3Apush),
+    and that a new image tag for your release version has [appeared on Docker
+    Hub](https://hub.docker.com/r/vectorim/matrix-content-scanner/tags).


### PR DESCRIPTION
Docker can't do multi-platform, qemu-based builds with the default `docker` driver. Install the `buildx` docker driver instead.

Follow-up to https://github.com/element-hq/matrix-content-scanner-python/pull/140. Fixes the v1.4.0 tag not being built: https://github.com/element-hq/matrix-content-scanner-python/actions/runs/33529752680/job/99929614372. Once approved, we can release a v1.4.1 with the working code.

Note: it would certainly be better to do native arm64 builds instead of using qemu. But we can tackle that in a new PR.